### PR TITLE
Switches to multi-OS role for updating packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
 # obf-ansible - Ansible playbooks for OBF-run servers
 
+## Install dependencies
+
+Playbooks here currently have the following dependencies:
+* Ansible Galaxy roles:
+    - `stafwag.package_update`
+    - Install roles from Ansible Galaxy like this:
+      ```sh
+      $ ansible-galaxy role install <ROLE_NAME>
+      ```
+      They will install into the default directory, typically
+      `~/.ansible/roles/` on Unix and macOS systems.
+
+## Run the playbooks
+
 Run in the following way:
 ```sh
 $ ansible-playbook -i hosts <PLAYBOOK>
 ```
 
 The following playbooks are currently available:
-* `update-reboot.yml` - Runs `yum update -y` across the AWS-hosted inventory,
-  and when complete reboots each one, waiting for each to come back.
+* `update-reboot.yml` - Runs OS-appropriate package updates across the
+  AWS-hosted inventory, and when complete reboots each one, waiting for
+  each to come back.

--- a/update-reboot.yml
+++ b/update-reboot.yml
@@ -2,10 +2,10 @@
 - name: perform yum update followed by reboot
   hosts: aws
   become: yes
-  remote_user: ec2-user
+#  debugger: on_failed
 
   roles:
-    - role: update
+    - role: stafwag.package_update
     - role: GROG.reboot
       reboot_wait: yes
       reboot_wait_delay: 60


### PR DESCRIPTION
This is in essence motivated by the rebuild of the mailman server, which uses Ubuntu instead of the Amazon Linux image (which is Redhat-based).